### PR TITLE
Fix the link to `User Attribute in Request`

### DIFF
--- a/Level_06/6_Sessions_and_authentication/Content/Readme.md
+++ b/Level_06/6_Sessions_and_authentication/Content/Readme.md
@@ -18,6 +18,6 @@ Let's take a quick example to see how we can set and get values from the session
 
 Further Reading:  
 - [Django Sessions](https://docs.djangoproject.com/en/4.0/topics/http/sessions/)
-- [User Attribute in Request](https://docs.djangoproject.com/en/4.0/topics/http/sessions/)
+- [User Attribute in Request](https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.HttpRequest.user)
 - [Using the Django Authentication System](https://docs.djangoproject.com/en/4.0/topics/auth/default/#using-the-django-authentication-system)
 > Read about the authenticate method [here](https://docs.djangoproject.com/en/4.0/topics/auth/default/#using-the-django-authentication-system), The authenticate method actually logs in a user, this is how the login view works internally.


### PR DESCRIPTION
The `User Attribute in Request` was pointing to https://docs.djangoproject.com/en/4.0/topics/http/sessions/
But the correct url is https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.HttpRequest.user